### PR TITLE
Fix atom getter being called multiple times on first load

### DIFF
--- a/atomic-redux-state-react/.eslintrc.json
+++ b/atomic-redux-state-react/.eslintrc.json
@@ -20,6 +20,10 @@
         "react",
         "@typescript-eslint"
     ],
+    "ignorePatterns": [
+        "node_modules",
+        "**/out/**"
+    ],
     "rules": {
         "comma-dangle": ["error", "never"],
         "indent": ["error", 4, {

--- a/atomic-redux-state-react/src/hooks/atomic-hooks.ts
+++ b/atomic-redux-state-react/src/hooks/atomic-hooks.ts
@@ -4,7 +4,7 @@ import {
     LoadingAtom, setAtom, SyncOrAsyncValue, ValueOrSetter, WritableAtom
 } from 'atomic-redux-state';
 import { Immutable } from 'immer';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 const useAtomicSelector = <T>(selector: (state: AtomicStoreState) => T) => useSelector<AtomicStoreState, T>(selector);
@@ -14,9 +14,7 @@ export function useAtomicValue<T>(atom: Atom<T, AtomValue<T>>): Immutable<T>;
 export function useAtomicValue<T>(atom: Atom<T, SyncOrAsyncValue<T>>): Immutable<T> | LoadingAtom;
 export function useAtomicValue<T>(atom: Atom<T, SyncOrAsyncValue<T>>): Immutable<T> | LoadingAtom {
     const dispatch = useDispatch();
-    useEffect(() => {
-        dispatch(initialiseAtom(atom));
-    }, []);
+    dispatch(initialiseAtom(atom));
     return useAtomicSelector(state => getAtomValueFromState(state, atom));
 }
 

--- a/atomic-redux-state/.eslintrc.json
+++ b/atomic-redux-state/.eslintrc.json
@@ -20,6 +20,10 @@
         "react",
         "@typescript-eslint"
     ],
+    "ignorePatterns": [
+        "node_modules",
+        "**/out/**"
+    ],
     "rules": {
         "comma-dangle": ["error", "never"],
         "indent": ["error", 4, {

--- a/atomic-redux-state/src/index.ts
+++ b/atomic-redux-state/src/index.ts
@@ -4,10 +4,9 @@ export {
     default as atomsReducer,
     getAtomValueFromState, initialiseAtom, initialiseAtomFromState,
     initialiseAtomFromStore,
-    isAtomUpdating,
-    setAtom
+    isAtomUpdating, selectAtom, setAtom
 } from './atomic-redux-state/atom-slice';
-export type { AtomicStoreState, AtomSliceState, selectAtom, SetAtomPayload } from './atomic-redux-state/atom-slice';
+export type { AtomicStoreState, AtomSliceState, SetAtomPayload } from './atomic-redux-state/atom-slice';
 export type { Atom, SyncOrAsyncValue, WritableAtom } from './atomic-redux-state/atom-types';
 export { derivedAtom } from './atomic-redux-state/derived-atom';
 export { DefaultValue, LoadingAtom } from './atomic-redux-state/getter-setter-utils';

--- a/common/changes/atomic-redux-state-react/feature-initial-load-caching_2022-06-22-16-39.json
+++ b/common/changes/atomic-redux-state-react/feature-initial-load-caching_2022-06-22-16-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "atomic-redux-state-react",
+      "comment": "Fix duplicate atom getter calls",
+      "type": "patch"
+    }
+  ],
+  "packageName": "atomic-redux-state-react"
+}

--- a/common/changes/atomic-redux-state/feature-initial-load-caching_2022-06-22-16-39.json
+++ b/common/changes/atomic-redux-state/feature-initial-load-caching_2022-06-22-16-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "atomic-redux-state",
+      "comment": "Publish selectAtom as value instead of type",
+      "type": "patch"
+    }
+  ],
+  "packageName": "atomic-redux-state"
+}


### PR DESCRIPTION
Dispatch the `initialiseAtom` action synchronously in `useAtomicValue` hook instead of as an effect, in order to prevent atom getters being called multiple times on page load if other atoms depend on it.