### PR TITLE
Add `toReadonly()` method to atom.

### DIFF
--- a/atomic-redux-state-react/.eslintrc.json
+++ b/atomic-redux-state-react/.eslintrc.json
@@ -6,7 +6,8 @@
     },
     "extends": [
         "plugin:react/recommended",
-        "airbnb"
+        "airbnb",
+        "airbnb-typescript"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/atomic-redux-state-react/package.json
+++ b/atomic-redux-state-react/package.json
@@ -28,8 +28,8 @@
     "lint": "eslint \"src/**\"",
     "lint-fix": "eslint --fix \"src/**\"",
     "prepack": "yarn lint-fix && jest && yarn build",
-    "test": "jest",
-    "preversion": "jest",
+    "test": "jest --verbose",
+    "preversion": "jest --verbose",
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
@@ -58,6 +58,7 @@
     "jest-standard-reporter": "~2.0.0",
     "react-dom": "~18.1.0",
     "ts-jest": "~28.0.4",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "eslint-config-airbnb-typescript": "~17.0.0"
   }
 }

--- a/atomic-redux-state/.eslintrc.json
+++ b/atomic-redux-state/.eslintrc.json
@@ -6,7 +6,8 @@
     },
     "extends": [
         "plugin:react/recommended",
-        "airbnb"
+        "airbnb",
+        "airbnb-typescript"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/atomic-redux-state/package.json
+++ b/atomic-redux-state/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint \"src/**\"",
     "lint-fix": "eslint --fix \"src/**\"",
     "prepack": "yarn lint-fix && jest && yarn build",
-    "test": "jest",
+    "test": "jest --verbose",
     "preversion": "jest",
     "postversion": "git push && git push --tags"
   },
@@ -50,6 +50,7 @@
     "jest": "~28.1.1",
     "jest-standard-reporter": "~2.0.0",
     "ts-jest": "~28.0.4",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "eslint-config-airbnb-typescript": "~17.0.0"
   }
 }

--- a/atomic-redux-state/src/atomic-redux-state/atom-types.ts
+++ b/atomic-redux-state/src/atomic-redux-state/atom-types.ts
@@ -5,6 +5,9 @@ export type SyncOrAsyncValue<T> = AtomValue<T> | AsyncAtomValue<T>;
 export interface Atom<T, U extends SyncOrAsyncValue<T>> {
     key: string;
     get: U;
+    /**
+     * Returns a read-only copy of the atom.
+     */
     toReadonly(): Atom<T, U>;
 }
 

--- a/atomic-redux-state/src/atomic-redux-state/atom-types.ts
+++ b/atomic-redux-state/src/atomic-redux-state/atom-types.ts
@@ -5,10 +5,31 @@ export type SyncOrAsyncValue<T> = AtomValue<T> | AsyncAtomValue<T>;
 export interface Atom<T, U extends SyncOrAsyncValue<T>> {
     key: string;
     get: U;
+    toReadonly(): Atom<T, U>;
+}
+
+/** @internal */
+export class ReadOnlyAtom<T, U extends SyncOrAsyncValue<T>> implements Atom<T, U> {
+    constructor(public key: string, public get: U) {}
+
+    toReadonly(): Atom<T, U> {
+        return this;
+    }
 }
 
 export interface WritableAtom<T, U extends SyncOrAsyncValue<T>> extends Atom<T, U> {
     set: AtomUpdateFunction<T>;
+}
+
+/** @internal */
+export class ReadWriteAtom<T, U extends SyncOrAsyncValue<T>> extends ReadOnlyAtom<T, U> implements WritableAtom<T, U> {
+    constructor(key: string, get: U, public set: AtomUpdateFunction<T>) {
+        super(key, get);
+    }
+
+    toReadonly(): Atom<T, U> {
+        return new ReadOnlyAtom(this.key, this.get);
+    }
 }
 
 export function isWritableAtom<T, U extends SyncOrAsyncValue<T>>(atom: Atom<T, U>): atom is WritableAtom<T, U> {

--- a/atomic-redux-state/src/atomic-redux-state/atom.spec.ts
+++ b/atomic-redux-state/src/atomic-redux-state/atom.spec.ts
@@ -1,4 +1,5 @@
 import { atom } from './atom';
+import { ReadOnlyAtom } from './atom-types';
 import { DefaultValue, GetOptions, SetOptions } from './getter-setter-utils';
 
 describe('atom', () => {
@@ -102,6 +103,22 @@ describe('atom', () => {
             testAtom.set({} as SetOptions, new DefaultValue(), mockSetCallback);
 
             expect(mockSetCallback).toHaveBeenCalledWith(defaultValue);
+        });
+    });
+
+    describe('toReadonly', () => {
+        it('should return a ReadOnlyAtom', () => {
+            const testKey = 'test-atom';
+            const testAtom = atom({
+                key: testKey,
+                default: 0
+            });
+
+            const readonlyAtom = testAtom.toReadonly();
+
+            expect(readonlyAtom).toBeInstanceOf(ReadOnlyAtom);
+            // @ts-ignore - Testing that this method does not exist despite the typing indicating it doesn't
+            expect(readonlyAtom.set).toBeUndefined();
         });
     });
 });

--- a/atomic-redux-state/src/atomic-redux-state/atom.ts
+++ b/atomic-redux-state/src/atomic-redux-state/atom.ts
@@ -1,4 +1,4 @@
-import { WritableAtom } from './atom-types';
+import { ReadOnlyAtom, WritableAtom } from './atom-types';
 import { AtomValue, DefaultValue } from './getter-setter-utils';
 
 export type AtomInitialiser<T> = {
@@ -22,6 +22,9 @@ export function atom<T>(initialiser: AtomInitialiser<T>): WritableAtom<T, AtomVa
             }
 
             setAtomValue(value);
-        }
+        },
+        toReadonly() {
+            return new ReadOnlyAtom(initialiser.key, this.get);
+        },
     };
 }

--- a/atomic-redux-state/src/atomic-redux-state/derived-atom.spec.ts
+++ b/atomic-redux-state/src/atomic-redux-state/derived-atom.spec.ts
@@ -1,3 +1,4 @@
+import { ReadOnlyAtom } from './atom-types';
 import { derivedAtom } from './derived-atom';
 
 describe('derived-atom', () => {
@@ -18,5 +19,21 @@ describe('derived-atom', () => {
         });
 
         expect(testAtom.set).toBeDefined();
+    });
+
+    describe('toReadonly', () => {
+        it('should return read-only atom', () => {
+            const testAtom = derivedAtom({
+                key: 'test-atom',
+                get: () => { },
+                set: () => { }
+            });
+
+            const readonlyAtom = testAtom.toReadonly();
+
+            expect(readonlyAtom).toBeInstanceOf(ReadOnlyAtom);
+            // @ts-ignore - Testing that this method does not exist despite the typing indicating it doesn't
+            expect(readonlyAtom.set).toBeUndefined();
+        });
     });
 });

--- a/atomic-redux-state/src/atomic-redux-state/derived-atom.ts
+++ b/atomic-redux-state/src/atomic-redux-state/derived-atom.ts
@@ -1,4 +1,4 @@
-import { Atom, WritableAtom } from './atom-types';
+import { Atom, ReadOnlyAtom, ReadWriteAtom, WritableAtom } from './atom-types';
 import { AsyncAtomValue, AtomValue, DefaultValue, GetOptions, SetOptions } from './getter-setter-utils';
 
 type SyncGetType<T> = (args: GetOptions) => T;
@@ -27,16 +27,9 @@ export function derivedAtom<T, G extends GetType<T>>(
     initialiser: DerivedAtomInitialiser<T, G>
 ): Atom<T, G> | WritableAtom<T, G> {
     if (isWritableInitialiser(initialiser)) {
-        return {
-            key: initialiser.key,
-            get: initialiser.get,
-            set: initialiser.set
-        };
+        return new ReadWriteAtom(initialiser.key, initialiser.get, initialiser.set);
     }
-    return {
-        key: initialiser.key,
-        get: initialiser.get
-    };
+    return new ReadOnlyAtom(initialiser.key, initialiser.get);
 }
 
 function isWritableInitialiser<T, G extends GetType<T>>(

--- a/common/changes/atomic-redux-state-react/feature-readonly-atoms_2022-06-24-20-52.json
+++ b/common/changes/atomic-redux-state-react/feature-readonly-atoms_2022-06-24-20-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "atomic-redux-state-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "atomic-redux-state-react"
+}

--- a/common/changes/atomic-redux-state/feature-readonly-atoms_2022-06-24-20-52.json
+++ b/common/changes/atomic-redux-state/feature-readonly-atoms_2022-06-24-20-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "atomic-redux-state",
+      "comment": "Add toReadonly method to atoms",
+      "type": "minor"
+    }
+  ],
+  "packageName": "atomic-redux-state"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -39,6 +39,7 @@ specifiers:
   dotenv-expand: ^5.1.0
   eslint: ^8.9.0
   eslint-config-airbnb: ^19.0.4
+  eslint-config-airbnb-typescript: ~17.0.0
   eslint-config-next: 12.1.6
   eslint-config-react-app: ^7.0.1
   eslint-plugin-import: ^2.25.4
@@ -81,6 +82,7 @@ specifiers:
   tailwindcss: ^3.0.2
   terser-webpack-plugin: ^5.2.5
   ts-jest: ~28.0.4
+  typed-redux-saga: ~1.5.0
   typescript: ^4.5.5
   webpack: ^5.64.4
   webpack-dev-server: ^4.6.0
@@ -126,6 +128,7 @@ dependencies:
   dotenv-expand: 5.1.0
   eslint: 8.17.0
   eslint-config-airbnb: 19.0.4_790ac381f0561db09e4c291cb829676e
+  eslint-config-airbnb-typescript: 17.0.0_1a4a6bb2631fa2a68d16837765ffefbb
   eslint-config-next: 12.1.6_85a02a54f427868067898054ce8dfb78
   eslint-config-react-app: 7.0.1_d6ff458c8016522ffa875501e7e9305f
   eslint-plugin-import: 2.26.0_eslint@8.17.0
@@ -168,6 +171,7 @@ dependencies:
   tailwindcss: 3.0.24
   terser-webpack-plugin: 5.3.3_webpack@5.73.0
   ts-jest: 28.0.4_e490584784132dcb4d7a2b1fd0409039
+  typed-redux-saga: 1.5.0_redux-saga@1.1.3
   typescript: 4.7.3
   webpack: 5.73.0
   webpack-dev-server: 4.9.1_webpack@5.73.0
@@ -5124,6 +5128,21 @@ packages:
       object.assign: 4.1.2
       object.entries: 1.1.5
       semver: 6.3.0
+    dev: false
+
+  /eslint-config-airbnb-typescript/17.0.0_1a4a6bb2631fa2a68d16837765ffefbb:
+    resolution: {integrity: sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.13.0
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^7.32.0 || ^8.2.0
+      eslint-plugin-import: ^2.25.3
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.27.0_53a3a26d566b734365db03aac28a1a58
+      '@typescript-eslint/parser': 5.27.0_eslint@8.17.0+typescript@4.7.3
+      eslint: 8.17.0
+      eslint-config-airbnb-base: 15.0.0_de2e8b5f32821e366389b4575f54c566
+      eslint-plugin-import: 2.26.0_eslint@8.17.0
     dev: false
 
   /eslint-config-airbnb/19.0.4_790ac381f0561db09e4c291cb829676e:
@@ -11731,7 +11750,7 @@ packages:
     dev: false
 
   file:projects/atomic-redux-state-react.tgz_223924243b7a5a8320b6da2d2be7c7f2:
-    resolution: {integrity: sha512-uX5vptJ3frDh2mBJMIAgQ73QgJCUmOo0tEH6R7mIsALRMZGW5AXEy99tKK73E+VomEzoCNjFILq/hkzWJXLuKQ==, tarball: file:projects/atomic-redux-state-react.tgz}
+    resolution: {integrity: sha512-Zh7YkS7hcfR6SKKjjG5NLSa6/OgPs0P5FPDPf9/5Ok7Z7Ni+e9efnl7dSkU1O62yzgdacw2TtBaqzWwYRLNf4A==, tarball: file:projects/atomic-redux-state-react.tgz}
     id: file:projects/atomic-redux-state-react.tgz
     name: '@rush-temp/atomic-redux-state-react'
     version: 0.0.0
@@ -11745,6 +11764,7 @@ packages:
       '@typescript-eslint/parser': 5.27.0_eslint@8.17.0+typescript@4.7.3
       eslint: 8.17.0
       eslint-config-airbnb: 19.0.4_790ac381f0561db09e4c291cb829676e
+      eslint-config-airbnb-typescript: 17.0.0_1a4a6bb2631fa2a68d16837765ffefbb
       eslint-plugin-import: 2.26.0_eslint@8.17.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.17.0
       eslint-plugin-react: 7.30.0_eslint@8.17.0
@@ -11774,7 +11794,7 @@ packages:
     dev: false
 
   file:projects/atomic-redux-state.tgz_6dffb028017529583fc86be525983951:
-    resolution: {integrity: sha512-m8060nmY6nCYr4bUty0MQCeiI/AAAW4ugvuEha5jeyNNzX2a5IMMLXuBvWBim7xk676HhJHKq0sJHxj/lZokfA==, tarball: file:projects/atomic-redux-state.tgz}
+    resolution: {integrity: sha512-a++z8pHD9qpH9+gPTAKO5qoH2Pt1TzL/PJgj/y8yvyz50XfjP5sUSRBu4l/MVRLfzr9hOxQWaAClpQBHZIVlTw==, tarball: file:projects/atomic-redux-state.tgz}
     id: file:projects/atomic-redux-state.tgz
     name: '@rush-temp/atomic-redux-state'
     version: 0.0.0
@@ -11787,6 +11807,7 @@ packages:
       babel-jest: 28.1.1_@babel+core@7.18.2
       eslint: 8.17.0
       eslint-config-airbnb: 19.0.4_790ac381f0561db09e4c291cb829676e
+      eslint-config-airbnb-typescript: 17.0.0_1a4a6bb2631fa2a68d16837765ffefbb
       eslint-plugin-import: 2.26.0_eslint@8.17.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.17.0
       eslint-plugin-react: 7.30.0_eslint@8.17.0


### PR DESCRIPTION
Add `toReadonly()` method to atom that returns read-only copy of atom.
Update eslint config to include airbnb-typescript.