### PR TITLE
Fix atom depth in graph not updating when graph edge removed

### DIFF
--- a/atomic-redux-state/src/atomic-redux-state/atom-middleware-slice.spec.ts
+++ b/atomic-redux-state/src/atomic-redux-state/atom-middleware-slice.spec.ts
@@ -1,0 +1,115 @@
+import { configureStore } from '@reduxjs/toolkit';
+import {
+    atomMiddlewareReducer, internalAddGraphConnection, internalAddNodeToGraph, internalRemoveGraphConnection
+} from './atom-middleware-slice';
+
+describe('AtomMiddlewareSlice', () => {
+    it('should set graph dependencies correctly when atoms added', () => {
+        const store = configureStore({
+            reducer: atomMiddlewareReducer
+        });
+
+        store.dispatch(internalAddNodeToGraph('a'));
+        store.dispatch(internalAddNodeToGraph('b'));
+        store.dispatch(internalAddNodeToGraph('c'));
+        store.dispatch(internalAddNodeToGraph('d'));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'a',
+            toAtomKey: 'b'
+        }));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'b',
+            toAtomKey: 'c'
+        }));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'b',
+            toAtomKey: 'd'
+        }));
+
+        const graph = store.getState().graph;
+
+        expect(graph.a?.dependencies).toEqual([]);
+        expect(graph.b?.dependencies).toEqual(['a']);
+        expect(graph.c?.dependencies).toEqual(['b']);
+        expect(graph.d?.dependencies).toEqual(['b']);
+
+        expect(graph.a?.dependants).toEqual(['b']);
+        expect(graph.b?.dependants).toEqual(['c', 'd']);
+        expect(graph.c?.dependants).toEqual([]);
+        expect(graph.d?.dependants).toEqual([]);
+    });
+
+    it('should set graph depth correctly when atoms added', () => {
+        const store = configureStore({
+            reducer: atomMiddlewareReducer
+        });
+
+        store.dispatch(internalAddNodeToGraph('a'));
+        store.dispatch(internalAddNodeToGraph('b'));
+        store.dispatch(internalAddNodeToGraph('c'));
+        store.dispatch(internalAddNodeToGraph('d'));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'a',
+            toAtomKey: 'b'
+        }));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'b',
+            toAtomKey: 'c'
+        }));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'b',
+            toAtomKey: 'd'
+        }));
+
+        const graph = store.getState().graph;
+
+        expect(graph.a?.depth).toEqual(2);
+        expect(graph.b?.depth).toEqual(1);
+        expect(graph.c?.depth).toEqual(0);
+        expect(graph.d?.depth).toEqual(0);
+    });
+
+    it('should update graph depth when graph edge removed', () => {
+        const store = configureStore({
+            reducer: atomMiddlewareReducer
+        });
+
+        store.dispatch(internalAddNodeToGraph('a'));
+        store.dispatch(internalAddNodeToGraph('b'));
+        store.dispatch(internalAddNodeToGraph('c'));
+        store.dispatch(internalAddNodeToGraph('d'));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'a',
+            toAtomKey: 'c'
+        }));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'b',
+            toAtomKey: 'c'
+        }));
+
+        store.dispatch(internalAddGraphConnection({
+            fromAtomKey: 'c',
+            toAtomKey: 'd'
+        }));
+
+        store.dispatch(internalRemoveGraphConnection({
+            fromAtomKey: 'c',
+            toAtomKey: 'd'
+        }));
+
+        const graph = store.getState().graph;
+
+        expect(graph.a?.depth).toEqual(1);
+        expect(graph.b?.depth).toEqual(1);
+        expect(graph.c?.depth).toEqual(0);
+        expect(graph.d?.depth).toEqual(0);
+    });
+});

--- a/atomic-redux-state/src/atomic-redux-state/atom-middleware.ts
+++ b/atomic-redux-state/src/atomic-redux-state/atom-middleware.ts
@@ -54,8 +54,7 @@ function createAtomGetter(
         atomStack.push(previousAtom.key);
         middlewareStore.dispatch(internalAddGraphConnection({
             fromAtomKey: previousAtom.key,
-            toAtomKey: currentAtom.key,
-            fromAtomDepth: atomStack.length
+            toAtomKey: currentAtom.key
         }));
 
         checkForDependencyLoop(atomStack);
@@ -89,8 +88,7 @@ function createAsyncAtomGetter(
         atomStack.push(previousAtom.key);
         middlewareStore.dispatch(internalAddGraphConnection({
             fromAtomKey: previousAtom.key,
-            toAtomKey: currentAtom.key,
-            fromAtomDepth: atomStack.length
+            toAtomKey: currentAtom.key
         }));
 
         checkForDependencyLoop(atomStack);

--- a/common/changes/atomic-redux-state/bugfix-depth-when-graph-edge-removed_2022-07-21-21-16.json
+++ b/common/changes/atomic-redux-state/bugfix-depth-when-graph-edge-removed_2022-07-21-21-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "atomic-redux-state",
+      "comment": "Fix graph depth not updating when edge removed from graph",
+      "type": "patch"
+    }
+  ],
+  "packageName": "atomic-redux-state"
+}


### PR DESCRIPTION
Caused devtools to display atoms at wrong depth level after a graph edge was removed (e.g. a conditional `get(atom)` inside derived atom getter)